### PR TITLE
src/TinyGsmModem.tpp: fix registration state

### DIFF
--- a/src/TinyGsmModem.tpp
+++ b/src/TinyGsmModem.tpp
@@ -192,7 +192,7 @@ class TinyGsmModem {
                                            GF("+CEREG:"));
     if (resp != 1 && resp != 2 && resp != 3) { return -1; }
     thisModem().streamSkipUntil(','); /* Skip format (0) */
-    int status = thisModem().streamGetIntBefore('\n');
+    int status = thisModem().stream.parseInt();
     thisModem().waitResponse();
     return status;
   }


### PR DESCRIPTION
As specified in the ETSI standards (e.g. ETSI TS 127 001), CREG and
CEREG responses can contain optional parameters:

+CEREG:         <n>,<stat>[,<tac>,<ci>[,<AcT>]]

For example, the Monarch GMS01Q returns the following response:

+CEREG: 2,1,"3982","00DF3B03",7

This results in TinyGSM setting state as '7' instead of 1 preventing
any connection.

Fix this by picking the next integer after the first ',' which will
always works (with or without optional parameters)

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>